### PR TITLE
fix: livetalk marquee length condition

### DIFF
--- a/src/components/LiveTalk.tsx
+++ b/src/components/LiveTalk.tsx
@@ -2,6 +2,9 @@ import { LiveChatDataInterface } from '@/data/LiveChatData';
 import { FC } from 'react';
 
 const LiveTalk: FC<LiveChatDataInterface> = ({ phone, message }) => {
+  const messageByteLength = new TextEncoder().encode(message).length;
+  const shouldMarquee = messageByteLength > 40;
+
   return (
     <div className="p-2 px-4 w-full bg-zinc-50 text-zinc-600">
       <div className="flex flex-row gap-2 text-[.7rem] overflow-hidden text-ellipsis">
@@ -11,7 +14,7 @@ const LiveTalk: FC<LiveChatDataInterface> = ({ phone, message }) => {
         <div className="flex flex-row gap-1">
           <span className="text-zinc-400 font-semibold">{phone}</span>
           <div className="w-full overflow-hidden text-ellipsis break-keep whitespace-pre">
-            <span className={message.length > 20 ? 'shortmarquee-content' : ''}>
+            <span className={shouldMarquee ? 'shortmarquee-content' : ''}>
               {message}
             </span>
           </div>


### PR DESCRIPTION
#5 에서 추가된 라이브톡 글귀가 컨테이너 영역을 벗어나나 marquee 효과가 적용되지 않는 현상을 수정합니다.

한글 1글자와 띄어쓰기 1회가 동일하게 length 1로 계산되는 것을 원인으로 판단해, byte stream으로 변환된 length를 기준으로 계산하도록 변경했습니다.

https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#browser_compatibility